### PR TITLE
Fix universal binary validator

### DIFF
--- a/test-fixtures/Makefile
+++ b/test-fixtures/Makefile
@@ -1,2 +1,6 @@
 all:
 	cd fixture-ls && make
+
+non-mach-o:
+	GOOS=linux GOARCH=amd64 go build -o linux_amd64 fixture-non-mach-o/main.go
+	mv linux_amd64 assets/

--- a/test-fixtures/Makefile
+++ b/test-fixtures/Makefile
@@ -1,6 +1,3 @@
 all:
 	cd fixture-ls && make
-
-non-mach-o:
-	GOOS=linux GOARCH=amd64 go build -o linux_amd64 fixture-non-mach-o/main.go
-	mv linux_amd64 assets/
+	cd fixture-non-mach-o && make

--- a/test-fixtures/assets/linux_amd64
+++ b/test-fixtures/assets/linux_amd64
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c42605766df4f22bb0809bc7281cc725f1b194225b9e85de6c33e0f5995f10df
+size 1149066

--- a/test-fixtures/fixture-non-mach-o/Makefile
+++ b/test-fixtures/fixture-non-mach-o/Makefile
@@ -1,0 +1,6 @@
+ROOT=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+CACHE_DIR=$(ROOT)/../assets
+
+non-mach-o:
+	GOOS=linux GOARCH=amd64 go build -o linux_amd64 main.go
+	mv linux_amd64 $(CACHE_DIR)

--- a/test-fixtures/fixture-non-mach-o/main.go
+++ b/test-fixtures/fixture-non-mach-o/main.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/universal_binary.go
+++ b/universal_binary.go
@@ -134,7 +134,7 @@ func (u *UniversalFile) Write(writer io.Writer) error {
 	return nil
 }
 
-// IsUniversalMachoBinary returns true if this is a multi-architecture (universal) binary.
+// IsUniversalMachoBinary returns true if this is a valid multi-architecture (universal) binary.
 func IsUniversalMachoBinary(reader io.ReaderAt) bool {
 	_, err := macho.NewFatFile(reader)
 	return err == nil

--- a/universal_binary.go
+++ b/universal_binary.go
@@ -3,7 +3,6 @@ package macho
 import (
 	"debug/macho"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -138,7 +137,7 @@ func (u *UniversalFile) Write(writer io.Writer) error {
 // IsUniversalMachoBinary returns true if this is a multi-architecture (universal) binary.
 func IsUniversalMachoBinary(reader io.ReaderAt) bool {
 	_, err := macho.NewFatFile(reader)
-	return !errors.Is(err, macho.ErrNotFat)
+	return err == nil
 }
 
 func ExtractReaders(r io.ReaderAt) ([]ExtractedReader, error) {

--- a/universal_binary_test.go
+++ b/universal_binary_test.go
@@ -201,6 +201,11 @@ func TestIsUniversalMachoBinary(t *testing.T) {
 			binaryPath: asset(t, "ls_amd64_signed"),
 			expected:   false,
 		},
+		{
+			name:       "negative case bin from different platform",
+			binaryPath: asset(t, "linux_main"),
+			expected:   false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/universal_binary_test.go
+++ b/universal_binary_test.go
@@ -218,60 +218,60 @@ func TestIsUniversalMachoBinary(t *testing.T) {
 }
 
 //// make will run the default make target for the given test fixture path
-// func runMakeTarget(t *testing.T, fixtureName string) {
-// 	cwd, err := os.Getwd()
-// 	if err != nil {
-// 		t.Errorf("unable to get cwd: %+v", err)
-// 	}
-// 	fixtureDir := filepath.Join(cwd, "test-fixtures/", fixtureName)
-
-// 	t.Logf("Generating Fixture in %q", fixtureDir)
-
-// 	cmd := exec.Command("make")
-// 	cmd.Dir = fixtureDir
-
-// 	stderr, err := cmd.StderrPipe()
-// 	if err != nil {
-// 		t.Fatalf("could not get stderr: %+v", err)
-// 	}
-// 	stdout, err := cmd.StdoutPipe()
-// 	if err != nil {
-// 		t.Fatalf("could not get stdout: %+v", err)
-// 	}
-
-// 	err = cmd.Start()
-// 	if err != nil {
-// 		t.Fatalf("failed to start cmd: %+v", err)
-// 	}
-
-// 	show := func(label string, reader io.ReadCloser) {
-// 		scanner := bufio.NewScanner(reader)
-// 		scanner.Split(bufio.ScanLines)
-// 		for scanner.Scan() {
-// 			t.Logf("%s: %s", label, scanner.Text())
-// 		}
-// 	}
-// 	go show("out", stdout)
-// 	go show("err", stderr)
-
-// 	if err := cmd.Wait(); err != nil {
-// 		if exiterr, ok := err.(*exec.ExitError); ok {
-// 			// The program has exited with an exit code != 0
-
-// 			// This works on both Unix and Windows. Although package
-// 			// syscall is generally platform dependent, WaitStatus is
-// 			// defined for both Unix and Windows and in both cases has
-// 			// an ExitStatus() method with the same signature.
-// 			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
-// 				if status.ExitStatus() != 0 {
-// 					t.Fatalf("failed to generate fixture: rc=%d", status.ExitStatus())
-// 				}
-// 			}
-// 		} else {
-// 			t.Fatalf("unable to get generate fixture result: %+v", err)
-// 		}
-// 	}
-// }
+//func runMakeTarget(t *testing.T, fixtureName string) {
+//	cwd, err := os.Getwd()
+//	if err != nil {
+//		t.Errorf("unable to get cwd: %+v", err)
+//	}
+//	fixtureDir := filepath.Join(cwd, "test-fixtures/", fixtureName)
+//
+//	t.Logf("Generating Fixture in %q", fixtureDir)
+//
+//	cmd := exec.Command("make")
+//	cmd.Dir = fixtureDir
+//
+//	stderr, err := cmd.StderrPipe()
+//	if err != nil {
+//		t.Fatalf("could not get stderr: %+v", err)
+//	}
+//	stdout, err := cmd.StdoutPipe()
+//	if err != nil {
+//		t.Fatalf("could not get stdout: %+v", err)
+//	}
+//
+//	err = cmd.Start()
+//	if err != nil {
+//		t.Fatalf("failed to start cmd: %+v", err)
+//	}
+//
+//	show := func(label string, reader io.ReadCloser) {
+//		scanner := bufio.NewScanner(reader)
+//		scanner.Split(bufio.ScanLines)
+//		for scanner.Scan() {
+//			t.Logf("%s: %s", label, scanner.Text())
+//		}
+//	}
+//	go show("out", stdout)
+//	go show("err", stderr)
+//
+//	if err := cmd.Wait(); err != nil {
+//		if exiterr, ok := err.(*exec.ExitError); ok {
+//			// The program has exited with an exit code != 0
+//
+//			// This works on both Unix and Windows. Although package
+//			// syscall is generally platform dependent, WaitStatus is
+//			// defined for both Unix and Windows and in both cases has
+//			// an ExitStatus() method with the same signature.
+//			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+//				if status.ExitStatus() != 0 {
+//					t.Fatalf("failed to generate fixture: rc=%d", status.ExitStatus())
+//				}
+//			}
+//		} else {
+//			t.Fatalf("unable to get generate fixture result: %+v", err)
+//		}
+//	}
+//}
 
 // asset returns the path to the cached asset file for a generated test fixture
 func asset(t *testing.T, assetName string) string {

--- a/universal_binary_test.go
+++ b/universal_binary_test.go
@@ -184,7 +184,8 @@ func TestPackageUniversalBinary(t *testing.T) {
 }
 
 func TestIsUniversalMachoBinary(t *testing.T) {
-	//runMakeTarget(t, "fixture-ls")
+	// runMakeTarget(t, "fixture-ls")
+	// runMakeTarget(t, "fixture-non-mach-o")
 
 	tests := []struct {
 		name       string
@@ -203,7 +204,7 @@ func TestIsUniversalMachoBinary(t *testing.T) {
 		},
 		{
 			name:       "negative case bin from different platform",
-			binaryPath: asset(t, "linux_main"),
+			binaryPath: asset(t, "linux_amd64"),
 			expected:   false,
 		},
 	}
@@ -217,60 +218,60 @@ func TestIsUniversalMachoBinary(t *testing.T) {
 }
 
 //// make will run the default make target for the given test fixture path
-//func runMakeTarget(t *testing.T, fixtureName string) {
-//	cwd, err := os.Getwd()
-//	if err != nil {
-//		t.Errorf("unable to get cwd: %+v", err)
-//	}
-//	fixtureDir := filepath.Join(cwd, "test-fixtures/", fixtureName)
-//
-//	t.Logf("Generating Fixture in %q", fixtureDir)
-//
-//	cmd := exec.Command("make")
-//	cmd.Dir = fixtureDir
-//
-//	stderr, err := cmd.StderrPipe()
-//	if err != nil {
-//		t.Fatalf("could not get stderr: %+v", err)
-//	}
-//	stdout, err := cmd.StdoutPipe()
-//	if err != nil {
-//		t.Fatalf("could not get stdout: %+v", err)
-//	}
-//
-//	err = cmd.Start()
-//	if err != nil {
-//		t.Fatalf("failed to start cmd: %+v", err)
-//	}
-//
-//	show := func(label string, reader io.ReadCloser) {
-//		scanner := bufio.NewScanner(reader)
-//		scanner.Split(bufio.ScanLines)
-//		for scanner.Scan() {
-//			t.Logf("%s: %s", label, scanner.Text())
-//		}
-//	}
-//	go show("out", stdout)
-//	go show("err", stderr)
-//
-//	if err := cmd.Wait(); err != nil {
-//		if exiterr, ok := err.(*exec.ExitError); ok {
-//			// The program has exited with an exit code != 0
-//
-//			// This works on both Unix and Windows. Although package
-//			// syscall is generally platform dependent, WaitStatus is
-//			// defined for both Unix and Windows and in both cases has
-//			// an ExitStatus() method with the same signature.
-//			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
-//				if status.ExitStatus() != 0 {
-//					t.Fatalf("failed to generate fixture: rc=%d", status.ExitStatus())
-//				}
-//			}
-//		} else {
-//			t.Fatalf("unable to get generate fixture result: %+v", err)
-//		}
-//	}
-//}
+// func runMakeTarget(t *testing.T, fixtureName string) {
+// 	cwd, err := os.Getwd()
+// 	if err != nil {
+// 		t.Errorf("unable to get cwd: %+v", err)
+// 	}
+// 	fixtureDir := filepath.Join(cwd, "test-fixtures/", fixtureName)
+
+// 	t.Logf("Generating Fixture in %q", fixtureDir)
+
+// 	cmd := exec.Command("make")
+// 	cmd.Dir = fixtureDir
+
+// 	stderr, err := cmd.StderrPipe()
+// 	if err != nil {
+// 		t.Fatalf("could not get stderr: %+v", err)
+// 	}
+// 	stdout, err := cmd.StdoutPipe()
+// 	if err != nil {
+// 		t.Fatalf("could not get stdout: %+v", err)
+// 	}
+
+// 	err = cmd.Start()
+// 	if err != nil {
+// 		t.Fatalf("failed to start cmd: %+v", err)
+// 	}
+
+// 	show := func(label string, reader io.ReadCloser) {
+// 		scanner := bufio.NewScanner(reader)
+// 		scanner.Split(bufio.ScanLines)
+// 		for scanner.Scan() {
+// 			t.Logf("%s: %s", label, scanner.Text())
+// 		}
+// 	}
+// 	go show("out", stdout)
+// 	go show("err", stderr)
+
+// 	if err := cmd.Wait(); err != nil {
+// 		if exiterr, ok := err.(*exec.ExitError); ok {
+// 			// The program has exited with an exit code != 0
+
+// 			// This works on both Unix and Windows. Although package
+// 			// syscall is generally platform dependent, WaitStatus is
+// 			// defined for both Unix and Windows and in both cases has
+// 			// an ExitStatus() method with the same signature.
+// 			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+// 				if status.ExitStatus() != 0 {
+// 					t.Fatalf("failed to generate fixture: rc=%d", status.ExitStatus())
+// 				}
+// 			}
+// 		} else {
+// 			t.Fatalf("unable to get generate fixture result: %+v", err)
+// 		}
+// 	}
+// }
 
 // asset returns the path to the cached asset file for a generated test fixture
 func asset(t *testing.T, assetName string) string {


### PR DESCRIPTION
Binaries of other platforms would passed as universal binaries, because they fail with: &FormatError{0, "invalid magic number", nil}, this PR fix that behavior.