### PR TITLE
chore(deps): restore Go version to 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anchore/go-macholibre
 
-go 1.26.2
+go 1.21
 
 require (
 	github.com/go-restruct/restruct v1.2.0-alpha


### PR DESCRIPTION
Restores the go directive in go.mod to 1.21 (pre-#68). Bumped in #68 (merge 4555029d37e7763b5c31fd3bc722f5d4d62fb911).