### PR TITLE
Tighten workflow-level permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,6 @@
 name: "Release"
 
-permissions:
-  contents: read
+permissions: {}
 
 # there should never be two releases in progress at the same time
 concurrency:

--- a/.github/workflows/validate-github-actions.yaml
+++ b/.github/workflows/validate-github-actions.yaml
@@ -10,8 +10,7 @@ on:
       - '.github/workflows/**'
       - '.github/actions/**'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   zizmor:

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -6,8 +6,7 @@ on:
       - main
   pull_request:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
 
@@ -15,6 +14,8 @@ jobs:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Static analysis"
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       # setup checkout, go, go-make, binny, and cache go modules
       - uses: anchore/go-make/.github/actions/setup@383ef7852b8ae43a30f424896b52479186d2ea4d # v0.1.0
@@ -26,6 +27,8 @@ jobs:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Unit tests"
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
Set top-level `permissions: {}` in all three workflow files so no permissions are granted at the workflow level by default. Per-job permissions that are actually needed are pushed down to the job level.

Changes:
- release.yaml: top-level `permissions: contents: read` → `permissions: {}` (release job already had `contents: write` at job level)
- validate-github-actions.yaml: top-level `permissions: contents: read` → `permissions: {}` (zizmor job already had job-level permissions)
- validations.yaml: top-level `permissions: contents: read` → `permissions: {}`; add `contents: read` to each job that needs it

Notes:
- No behavior change; jobs retain the permissions they need, just scoped more tightly